### PR TITLE
Mark reading progress by chapter ID

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -40,7 +40,7 @@ const api = {
     collectionSlug: string,
     seriesUrl: string,
     linkToUrl: ?string,
-    lastReadChapterId: string | null,
+    lastReadChapterId: string | null = null,
   ) =>
     instance.post(`/collection/${collectionSlug}/bookmark/new`, {
       seriesUrl,

--- a/src/api.js
+++ b/src/api.js
@@ -40,7 +40,7 @@ const api = {
     collectionSlug: string,
     seriesUrl: string,
     linkToUrl: ?string,
-    lastReadChapterId: ?string,
+    lastReadChapterId: string | null,
   ) =>
     instance.post(`/collection/${collectionSlug}/bookmark/new`, {
       seriesUrl,

--- a/src/api.js
+++ b/src/api.js
@@ -31,21 +31,21 @@ const api = {
   fetchMarkAsRead: (
     collectionSlug: string,
     seriesId: string,
-    lastReadAt: number,
+    lastReadChapterId: string | null,
   ) =>
     instance.post(`/collection/${collectionSlug}/bookmark/${seriesId}/read`, {
-      lastReadAt,
+      lastReadChapterId,
     }),
   fetchAddBookmarkToCollection: (
     collectionSlug: string,
     seriesUrl: string,
     linkToUrl: ?string,
-    lastReadAt: ?number,
+    lastReadChapterId: ?string,
   ) =>
     instance.post(`/collection/${collectionSlug}/bookmark/new`, {
       seriesUrl,
       linkToUrl,
-      lastReadAt,
+      lastReadChapterId,
     }),
   fetchRemoveBookmarkFromCollection: (
     collectionSlug: string,

--- a/src/components/reader-chapter-picker.js
+++ b/src/components/reader-chapter-picker.js
@@ -11,7 +11,7 @@ type Props = {
   activeChapterId?: string,
   activeChapterRef?: ElementRef<*>,
   seriesChapters: Chapter[],
-  lastReadAt?: number,
+  lastReadChapterId: ?string,
   onChapterClick: (chapter: Chapter) => void,
 };
 
@@ -56,14 +56,14 @@ export default class ReaderChapterPicker extends PureComponent<Props> {
     this.props.onChapterClick(chapter);
   };
 
-  renderChapters(chapters: Chapter[]) {
-    const { activeChapterId, activeChapterRef, lastReadAt } = this.props;
+  renderChapters(chapters: Chapter[], lastReadOrder: number) {
+    const { activeChapterId, activeChapterRef } = this.props;
 
     return (
       <div>
         {chapters.map(c => {
           const isActive = c.id === activeChapterId;
-          const isUnread = lastReadAt ? lastReadAt < c.createdAt : false;
+          const isUnread = c.order > lastReadOrder;
 
           return (
             <ChapterRow
@@ -81,10 +81,13 @@ export default class ReaderChapterPicker extends PureComponent<Props> {
   }
 
   render() {
-    const { seriesChapters } = this.props;
+    const { seriesChapters, lastReadChapterId } = this.props;
+
+    const lastRead = seriesChapters.find(c => c.id === lastReadChapterId);
+    const lastReadOrder = lastRead ? lastRead.order : 0;
 
     if (!shouldGroupByVolume(seriesChapters)) {
-      return this.renderChapters(seriesChapters);
+      return this.renderChapters(seriesChapters, lastReadOrder);
     }
 
     const groupedChapters = utils.groupBy(seriesChapters, 'volumeNumber');
@@ -99,7 +102,7 @@ export default class ReaderChapterPicker extends PureComponent<Props> {
                 Volume {key}
               </div>
             )}
-            {this.renderChapters(groupedChapters[key])}
+            {this.renderChapters(groupedChapters[key], lastReadOrder)}
           </div>
         ))}
       </div>

--- a/src/components/reader-chapter-picker.js
+++ b/src/components/reader-chapter-picker.js
@@ -11,7 +11,7 @@ type Props = {
   activeChapterId?: string,
   activeChapterRef?: ElementRef<*>,
   seriesChapters: Chapter[],
-  lastReadChapterId: ?string,
+  lastReadChapterId: string | null,
   onChapterClick: (chapter: Chapter) => void,
 };
 

--- a/src/components/reader-navigation.js
+++ b/src/components/reader-navigation.js
@@ -14,7 +14,7 @@ type Props = {
   chapter: Chapter,
   collection: ?Collection,
   onChapterSelectChange: (e: SyntheticInputEvent<HTMLSelectElement>) => void,
-  lastReadAt?: number,
+  lastReadChapterId: ?string,
   seriesChapters: Chapter[],
 };
 
@@ -75,7 +75,7 @@ export default class ReaderNavigation extends Component<Props, State> {
   }
 
   renderPickerPanel() {
-    const { chapter, lastReadAt, seriesChapters } = this.props;
+    const { chapter, lastReadChapterId, seriesChapters } = this.props;
     const { showingPanel } = this.state;
 
     if (showingPanel === false) {
@@ -99,7 +99,7 @@ export default class ReaderNavigation extends Component<Props, State> {
                 activeChapterRef={this.activeChapterRef}
                 activeChapterId={chapter.id}
                 seriesChapters={seriesChapters}
-                lastReadAt={lastReadAt}
+                lastReadChapterId={lastReadChapterId}
                 onChapterClick={this.handleChapterClick}
               />
             </div>

--- a/src/components/reader-navigation.js
+++ b/src/components/reader-navigation.js
@@ -14,7 +14,7 @@ type Props = {
   chapter: Chapter,
   collection: ?Collection,
   onChapterSelectChange: (e: SyntheticInputEvent<HTMLSelectElement>) => void,
-  lastReadChapterId: ?string,
+  lastReadChapterId: string | null,
   seriesChapters: Chapter[],
 };
 

--- a/src/containers/collection-feed.js
+++ b/src/containers/collection-feed.js
@@ -83,18 +83,29 @@ class Feed extends Component<Props, State> {
   };
 
   handleSeriesOptionsMarkAsReadClick = () => {
-    const { collection, dispatch } = this.props;
+    const { collection, dispatch, seriesById } = this.props;
     const { optionsPanelSeriesId } = this.state;
 
     if (!optionsPanelSeriesId) {
       return;
     }
 
+    const series: ?Series = seriesById[optionsPanelSeriesId];
+
+    if (!series) {
+      return;
+    }
+
+    const lastReadChapterId =
+      series.supportsReading !== true || !series.chapters
+        ? null
+        : utils.sortChapters(series.chapters)[0].id;
+
     dispatch(
       markSeriesAsRead(
         collection.slug,
         optionsPanelSeriesId,
-        utils.getTimestamp(),
+        lastReadChapterId,
       ),
     );
 
@@ -131,15 +142,7 @@ class Feed extends Component<Props, State> {
 
     const bookmark = collection.bookmarks[series.id];
     const allChapters = series.chapters.map(id => chaptersById[id]);
-    const unreadChapters = utils.getUnreadChapters(
-      allChapters,
-      bookmark.lastReadAt,
-    );
-
-    const toChapter =
-      unreadChapters.length > 0
-        ? utils.leastRecentChapter(unreadChapters)
-        : utils.mostRecentChapter(allChapters);
+    const toChapter = utils.nextChapterToRead(allChapters, bookmark);
 
     history.push(utils.getReaderUrl(collection.slug, toChapter.id));
   };

--- a/src/containers/collection-feed.js
+++ b/src/containers/collection-feed.js
@@ -153,7 +153,7 @@ class Feed extends Component<Props, State> {
     history.push(utils.getReaderUrl(collection.slug, toChapter.id));
   };
 
-  isSeriesUnread = (seriesId, lastReadChapterId): boolean => {
+  isSeriesUnread = (seriesId, lastReadChapterId: string | null): boolean => {
     const { chaptersById, seriesById } = this.props;
 
     const series = seriesById[seriesId];

--- a/src/containers/new-bookmark-panel.js
+++ b/src/containers/new-bookmark-panel.js
@@ -88,6 +88,7 @@ class NewBookmarkPanel extends Component<Props, State> {
         collectionSlug,
         utils.normalizeUrl(seriesUrl),
         linkToUrl ? utils.normalizeUrl(linkToUrl) : null,
+        null,
       )
       .then(response => {
         const normalized = normalize(response.data, {

--- a/src/store/reducers/collections.js
+++ b/src/store/reducers/collections.js
@@ -137,17 +137,19 @@ export function removeBookmark(
 export function markSeriesAsRead(
   collectionSlug: string,
   seriesId: string,
-  lastReadAt: number,
+  lastReadChapterId: string | null,
 ): Thunk {
   return (dispatch, getState, api) => {
     dispatch({
       type: 'MARK_BOOKMARK_AS_READ',
-      payload: { collectionSlug, seriesId, lastReadAt },
+      payload: { collectionSlug, seriesId, lastReadChapterId },
     });
 
-    api.fetchMarkAsRead(collectionSlug, seriesId, lastReadAt).catch(err => {
-      // swallow errors
-    });
+    api
+      .fetchMarkAsRead(collectionSlug, seriesId, lastReadChapterId)
+      .catch(err => {
+        // swallow errors
+      });
   };
 }
 
@@ -181,12 +183,12 @@ export default function reducer(
       }));
     }
     case 'MARK_BOOKMARK_AS_READ': {
-      const { collectionSlug, seriesId, lastReadAt } = action.payload;
+      const { collectionSlug, seriesId, lastReadChapterId } = action.payload;
 
       return utils.set(
         state,
-        `${collectionSlug}.bookmarks.${seriesId}.lastReadAt`,
-        lastReadAt,
+        `${collectionSlug}.bookmarks.${seriesId}.lastReadChapterId`,
+        lastReadChapterId,
       );
     }
     case 'REMOVE_BOOKMARK': {

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -53,7 +53,11 @@ export type RemoveBookmarkAction = ActionType<
 >;
 export type MarkBookmarkAsReadAction = ActionType<
   'MARK_BOOKMARK_AS_READ',
-  { collectionSlug: string, seriesId: string, lastReadChapterId: string },
+  {
+    collectionSlug: string,
+    seriesId: string,
+    lastReadChapterId: string | null,
+  },
 >;
 export type SetSeriesAction = ActionType<'SET_SERIES', Series>;
 export type SetSeriesEntityStatusAction = ActionType<

--- a/src/store/types.js
+++ b/src/store/types.js
@@ -53,7 +53,7 @@ export type RemoveBookmarkAction = ActionType<
 >;
 export type MarkBookmarkAsReadAction = ActionType<
   'MARK_BOOKMARK_AS_READ',
-  { collectionSlug: string, seriesId: string, lastReadAt: number },
+  { collectionSlug: string, seriesId: string, lastReadChapterId: string },
 >;
 export type SetSeriesAction = ActionType<'SET_SERIES', Series>;
 export type SetSeriesEntityStatusAction = ActionType<

--- a/src/types.js
+++ b/src/types.js
@@ -9,6 +9,7 @@ export type ChapterMetadata = {
   id: string,
   seriesId: string,
   createdAt: number,
+  order: number,
 };
 
 export type Chapter = {

--- a/src/types.js
+++ b/src/types.js
@@ -32,7 +32,7 @@ export type Series = {
 
 export type Bookmark = {
   id: string,
-  lastReadChapterId: string,
+  lastReadChapterId: string | null,
   url: string,
   linkTo: ?string,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -32,11 +32,12 @@ export type Series = {
 
 export type Bookmark = {
   id: string,
-  lastReadAt: number,
+  lastReadChapterId: string,
+  url: string,
   linkTo: ?string,
 };
 
 export type Collection = {
   slug: string,
-  bookmarks: Bookmark[],
+  bookmarks: { [id: string]: Bookmark },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ import set from 'clean-set';
 import { format, isToday, isYesterday } from 'date-fns';
 import groupBy from 'lodash.groupby';
 
-import type { Bookmark, Collection, Chapter, Series } from './types';
+import type { Bookmark, Collection, Chapter } from './types';
 
 const toDate = (n: number): Date => new Date(n * 1000);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,7 +147,7 @@ const utils = {
 
   nextChapterToRead: (
     chapters: Chapter[],
-    lastReadId: string | null,
+    lastReadId: string | null = null,
   ): Chapter => {
     const sortedChapters = utils.sortChapters(chapters);
     const unreadChapters = utils.getUnreadChapters(sortedChapters, lastReadId);

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,11 +71,11 @@ const utils = {
   /**
    * Collection Helpers
    */
-  getUnreadMap: (collection: Collection): { [string]: ?string } => {
+  getUnreadMap: (collection: Collection): { [string]: string | null } => {
     const bookmarks: Bookmark[] = Object.values(collection.bookmarks);
 
     return bookmarks.reduce((acc, bookmark) => {
-      acc[bookmark.id] = bookmark.lastReadChapterId;
+      acc[bookmark.id] = bookmark.lastReadChapterId || null;
       return acc;
     }, {});
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ import set from 'clean-set';
 import { format, isToday, isYesterday } from 'date-fns';
 import groupBy from 'lodash.groupby';
 
-import type { Bookmark, Collection, Chapter } from './types';
+import type { Bookmark, Collection, Chapter, Series } from './types';
 
 const toDate = (n: number): Date => new Date(n * 1000);
 
@@ -71,11 +71,11 @@ const utils = {
   /**
    * Collection Helpers
    */
-  getUnreadMap: (collection: Collection): { [string]: number } => {
+  getUnreadMap: (collection: Collection): { [string]: ?string } => {
     const bookmarks: Bookmark[] = Object.values(collection.bookmarks);
 
     return bookmarks.reduce((acc, bookmark) => {
-      acc[bookmark.id] = bookmark.lastReadAt;
+      acc[bookmark.id] = bookmark.lastReadChapterId;
       return acc;
     }, {});
   },
@@ -117,7 +117,7 @@ const utils = {
   getUnreadChapters: (chapters: Chapter[], lastReadId: string): Chapter[] => {
     const orderedChapters = utils.sortChapters(chapters);
     const lastReadIndex = orderedChapters.findIndex(c => c.id === lastReadId);
-    const unreadChapters = orderedChapters.slice(0, lastReadIndex - 1);
+    const unreadChapters = orderedChapters.slice(0, lastReadIndex);
 
     return unreadChapters;
   },
@@ -125,17 +125,14 @@ const utils = {
   getReadChapters: (chapters: Chapter[], lastReadId: string): Chapter[] => {
     const orderedChapters = utils.sortChapters(chapters);
     const lastReadIndex = orderedChapters.findIndex(c => c.id === lastReadId);
-    const readChapters = orderedChapters.slice(lastReadIndex);
+    const readChapters = orderedChapters.slice(lastReadIndex + 1);
 
     return readChapters;
   },
 
-  nextChapterToRead: (chapters: Chapter[], bookmark: Bookmark): Chapter => {
+  nextChapterToRead: (chapters: Chapter[], lastReadId: string): Chapter => {
     const sortedChapters = utils.sortChapters(chapters);
-    const unreadChapters = utils.getUnreadChapters(
-      sortedChapters,
-      bookmark.lastReadChapterId,
-    );
+    const unreadChapters = utils.getUnreadChapters(sortedChapters, lastReadId);
 
     // If there are later chapters, get the next one.
     if (unreadChapters.length > 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,7 +114,14 @@ const utils = {
     return chapters.slice().sort((a, b) => b.order - a.order);
   },
 
-  getUnreadChapters: (chapters: Chapter[], lastReadId: string): Chapter[] => {
+  getUnreadChapters: (
+    chapters: Chapter[],
+    lastReadId: string | null,
+  ): Chapter[] => {
+    if (lastReadId === null) {
+      return chapters;
+    }
+
     const orderedChapters = utils.sortChapters(chapters);
     const lastReadIndex = orderedChapters.findIndex(c => c.id === lastReadId);
     const unreadChapters = orderedChapters.slice(0, lastReadIndex);
@@ -122,7 +129,14 @@ const utils = {
     return unreadChapters;
   },
 
-  getReadChapters: (chapters: Chapter[], lastReadId: string): Chapter[] => {
+  getReadChapters: (
+    chapters: Chapter[],
+    lastReadId: string | null,
+  ): Chapter[] => {
+    if (lastReadId === null) {
+      return [];
+    }
+
     const orderedChapters = utils.sortChapters(chapters);
     const lastReadIndex = orderedChapters.findIndex(c => c.id === lastReadId);
     const readChapters = orderedChapters.slice(lastReadIndex + 1);
@@ -130,7 +144,10 @@ const utils = {
     return readChapters;
   },
 
-  nextChapterToRead: (chapters: Chapter[], lastReadId: string): Chapter => {
+  nextChapterToRead: (
+    chapters: Chapter[],
+    lastReadId: string | null,
+  ): Chapter => {
     const sortedChapters = utils.sortChapters(chapters);
     const unreadChapters = utils.getUnreadChapters(sortedChapters, lastReadId);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,13 +116,14 @@ const utils = {
 
   getUnreadChapters: (
     chapters: Chapter[],
-    lastReadId: string | null,
+    lastReadId: string | null = null,
   ): Chapter[] => {
+    const orderedChapters = utils.sortChapters(chapters);
+
     if (lastReadId === null) {
-      return chapters;
+      return orderedChapters;
     }
 
-    const orderedChapters = utils.sortChapters(chapters);
     const lastReadIndex = orderedChapters.findIndex(c => c.id === lastReadId);
     const unreadChapters = orderedChapters.slice(0, lastReadIndex);
 
@@ -131,7 +132,7 @@ const utils = {
 
   getReadChapters: (
     chapters: Chapter[],
-    lastReadId: string | null,
+    lastReadId: string | null = null,
   ): Chapter[] => {
     if (lastReadId === null) {
       return [];
@@ -139,7 +140,7 @@ const utils = {
 
     const orderedChapters = utils.sortChapters(chapters);
     const lastReadIndex = orderedChapters.findIndex(c => c.id === lastReadId);
-    const readChapters = orderedChapters.slice(lastReadIndex + 1);
+    const readChapters = orderedChapters.slice(lastReadIndex);
 
     return readChapters;
   },

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,6 +1,72 @@
 import utils from './utils';
 
 describe('utils', () => {
+  describe('sorting utils', () => {
+    const chapterA = { id: 'site:series:14616', order: 0 };
+    const chapterB = { id: 'site:series:14618', order: 1 };
+    const chapterC = { id: 'site:series:14617', order: 2 };
+    const chapterD = { id: 'site:series:14619', order: 3 };
+    const chapters = [chapterA, chapterB, chapterD, chapterC];
+
+    describe('sortChapters', () => {
+      it('sorts chapters in descending order', () => {
+        expect(utils.sortChapters(chapters)).toEqual([
+          chapterD,
+          chapterC,
+          chapterB,
+          chapterA,
+        ]);
+      });
+    });
+
+    describe('getUnreadChapters', () => {
+      it('returns every chapter later in the order, excluding the last read', () => {
+        expect(utils.getUnreadChapters(chapters, 'site:series:14619')).toEqual(
+          [],
+        );
+
+        expect(utils.getUnreadChapters(chapters, 'site:series:14617')).toEqual([
+          chapterD,
+        ]);
+
+        expect(utils.getUnreadChapters(chapters, 'site:series:14616')).toEqual([
+          chapterD,
+          chapterC,
+          chapterB,
+        ]);
+      });
+
+      it('returns every chapter if the last read chapter id is null', () => {
+        expect(utils.getUnreadChapters(chapters, null)).toEqual([
+          chapterD,
+          chapterC,
+          chapterB,
+          chapterA,
+        ]);
+      });
+    });
+
+    describe('getReadChapters', () => {
+      it('returns every chapter up to and including the last read chapter id', () => {
+        expect(utils.getReadChapters(chapters, 'site:series:14618')).toEqual([
+          chapterB,
+          chapterA,
+        ]);
+
+        expect(utils.getReadChapters(chapters, 'site:series:14619')).toEqual([
+          chapterD,
+          chapterC,
+          chapterB,
+          chapterA,
+        ]);
+      });
+
+      it('returns no chapters if the last read chapter id is null', () => {
+        expect(utils.getReadChapters(chapters, null)).toEqual([]);
+      });
+    });
+  });
+
   describe('chapter utils', () => {
     const standardChapter = {
       slug: '105',
@@ -21,11 +87,15 @@ describe('utils', () => {
 
     describe('getChapterLabel', () => {
       it('returns a formatted chapter number', () => {
-        expect(utils.getChapterLabel(standardChapter)).toEqual('Chapter 105');
+        expect(utils.getChapterLabel(standardChapter, true)).toEqual(
+          'Chapter 105',
+        );
       });
 
       it('returns the chapter title when no chapter number exists', () => {
-        expect(utils.getChapterLabel(chapterWithoutNumber)).toEqual('Oneshot');
+        expect(utils.getChapterLabel(chapterWithoutNumber, true)).toEqual(
+          'Oneshot',
+        );
       });
 
       it('returns the volume number when no other information exists', () => {

--- a/src/views/reader-view.js
+++ b/src/views/reader-view.js
@@ -51,7 +51,7 @@ class ReaderView extends Component<Props> {
 
     const chapterId = decodeURIComponent(rawChapterId);
     const seriesId = utils.toSeriesId(chapterId);
-    const series = state.series[seriesId];
+    const series: ?Series = state.series[seriesId];
 
     return {
       chapter: state.chapters[chapterId],
@@ -99,23 +99,33 @@ class ReaderView extends Component<Props> {
   };
 
   markSeriesAsRead = () => {
-    const { collection, series, chapter, dispatch } = this.props;
+    const {
+      collection,
+      series,
+      seriesChapters,
+      chapter,
+      dispatch,
+    } = this.props;
 
     if (!collection || !series || !chapter) {
       return;
     }
 
     const bookmark = collection.bookmarks[series.id];
-    const currentChapterReadAt = chapter.createdAt;
-    const latestReadAt = bookmark.lastReadAt;
 
-    if (latestReadAt > currentChapterReadAt) {
+    if (!bookmark) {
       return;
     }
 
-    dispatch(
-      markSeriesAsRead(collection.slug, series.id, currentChapterReadAt),
+    const lastReadChapter = seriesChapters.find(
+      c => c.id === bookmark.lastReadChapterId,
     );
+
+    if (lastReadChapter && chapter.order <= lastReadChapter.order) {
+      return;
+    }
+
+    dispatch(markSeriesAsRead(collection.slug, series.id, chapter.id));
   };
 
   handleChapterChange = (nextChapter: Chapter) => {
@@ -170,7 +180,7 @@ class ReaderView extends Component<Props> {
               <ReaderNavigation
                 collection={collection}
                 chapter={chapter}
-                lastReadAt={unreadMap[series.id]}
+                lastReadChapterId={unreadMap[series.id]}
                 onChapterSelectChange={this.handleChapterChange}
                 seriesChapters={seriesChapters}
               />
@@ -224,7 +234,7 @@ class ReaderView extends Component<Props> {
                     <ReaderNavigation
                       chapter={chapter}
                       collection={collection}
-                      lastReadAt={unreadMap[series.id]}
+                      lastReadChapterId={unreadMap[series.id]}
                       onChapterSelectChange={this.handleChapterChange}
                       seriesChapters={seriesChapters}
                     />


### PR DESCRIPTION
This PR leverages the work done on the backend repo to mark reading progress by a chapter's `id` rather than by its `createdAt` timestamp. While slightly more complicated, this will help split the idea of a _new_ chapter from an _unread_ one.

---

Fixes #21, #23 