### PR TITLE
Add smarter lazyloading image dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@rosszurowski/vanilla": "^1.3.2",
+    "array-most-common": "^1.0.0",
     "axios": "^0.18.0",
     "canvas-fit": "^1.5.0",
     "clean-set": "^1.1.0",

--- a/src/components/reader-page-image-list.js
+++ b/src/components/reader-page-image-list.js
@@ -1,0 +1,90 @@
+// @flow
+
+import React, { Component, Fragment } from 'react';
+import type { Page } from 'poketo';
+import mostCommon from 'array-most-common';
+import type { PageDimensions } from '../types';
+import ReaderPageImage from '../components/reader-page-image';
+
+type PageListProps = {
+  pages: Page[],
+};
+
+type PageListState = {
+  defaultPageWidth?: number,
+  defaultPageHeight?: number,
+};
+
+function serializeDimension(dimension: PageDimensions) {
+  return `${dimension.width}:${dimension.height}`;
+}
+
+function unserializeDimension(dimension: string) {
+  const [width, height] = dimension.split(':');
+  return { width, height };
+}
+
+function getMostCommonPageDimensions(
+  dimensions: PageDimensions[],
+): PageDimensions {
+  if (dimensions.length < 2) {
+    // If there's less than 3 pages, getting the most common dimensions is
+    // likely to be wrong, since the first few scans of a chapter often have
+    // title/introductory pages which are different ratios.
+    return { width: undefined, height: undefined };
+  }
+
+  const serializedDimensions = dimensions.map(serializeDimension);
+  const mostCommonSerialized = mostCommon(serializedDimensions);
+  const mostCommonDimension = unserializeDimension(mostCommonSerialized);
+
+  return mostCommonDimension;
+}
+
+export default class ReaderPageImageList extends Component<
+  PageListProps,
+  PageListState,
+> {
+  state = {
+    defaultPageWidth: undefined,
+    defaultPageHeight: undefined,
+  };
+
+  pageSizes: PageDimensions[] = [];
+
+  handleImageDimensionsLoad = (dimensions: PageDimensions) => {
+    this.pageSizes.push(dimensions);
+
+    const {
+      width: defaultPageWidth,
+      height: defaultPageHeight,
+    } = getMostCommonPageDimensions(this.pageSizes);
+
+    if (
+      defaultPageWidth !== this.state.defaultPageWidth ||
+      defaultPageHeight !== this.state.defaultPageHeight
+    ) {
+      this.setState({ defaultPageWidth, defaultPageHeight });
+    }
+  };
+
+  render() {
+    const { pages } = this.props;
+    const { defaultPageWidth, defaultPageHeight } = this.state;
+
+    return (
+      <Fragment>
+        {pages.map(page => (
+          <div key={page.id} className="mb-2 mb-3-m">
+            <ReaderPageImage
+              page={page}
+              defaultWidth={defaultPageWidth}
+              defaultHeight={defaultPageHeight}
+              onImageDimensionsLoad={this.handleImageDimensionsLoad}
+            />
+          </div>
+        ))}
+      </Fragment>
+    );
+  }
+}

--- a/src/components/reader-page-image-list.js
+++ b/src/components/reader-page-image-list.js
@@ -28,8 +28,8 @@ function getMostCommonPageDimensions(
   dimensions: PageDimensions[],
 ): PageDimensions {
   if (dimensions.length < 2) {
-    // If there's less than 3 pages, getting the most common dimensions is
-    // likely to be wrong, since the first few scans of a chapter often have
+    // If there's less than 2 pages loaded, getting the most common dimensions
+    // is likely to be wrong, since the first few pages of a chapter often have
     // title/introductory pages which are different ratios.
     return { width: undefined, height: undefined };
   }

--- a/src/components/reader-page-image.js
+++ b/src/components/reader-page-image.js
@@ -4,6 +4,7 @@ import React, { PureComponent } from 'react';
 import { cx, css } from 'react-emotion/macro';
 import Button from './button';
 import Icon from './icon';
+import type { PageDimensions } from '../types';
 
 if (typeof global.window !== 'undefined') {
   global.window.lazySizesConfig = window.lazySizesConfig || {};
@@ -49,16 +50,24 @@ type Props = {
     width?: number,
     height?: number,
   },
+  defaultWidth: number,
+  defaultHeight: number,
+  onImageDimensionsLoad: PageDimensions => void,
 };
 
 type State = {
   hasError: boolean,
 };
 
-const DEFAULT_WIDTH = 800;
-const DEFAULT_HEIGHT = 1050;
+const PLACEHOLDER_SIZE_IN_PX = 1;
 
 export default class ReaderPageImage extends PureComponent<Props, State> {
+  static defaultProps = {
+    defaultWidth: 800,
+    defaultHeight: 1050,
+    onImageDimensionsLoad: () => {},
+  };
+
   state = {
     hasError: false,
   };
@@ -69,6 +78,20 @@ export default class ReaderPageImage extends PureComponent<Props, State> {
 
   handleLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     this.setState({ hasError: false });
+
+    const target = e.currentTarget;
+    const isPlaceholder =
+      target.width === PLACEHOLDER_SIZE_IN_PX &&
+      target.height === PLACEHOLDER_SIZE_IN_PX;
+
+    if (!isPlaceholder) {
+      const dimensions: PageDimensions = {
+        width: target.width,
+        height: target.height,
+      };
+
+      this.props.onImageDimensionsLoad(dimensions);
+    }
   };
 
   handleRetryClick = (e: SyntheticMouseEvent<HTMLButtonElement>) => {
@@ -76,9 +99,9 @@ export default class ReaderPageImage extends PureComponent<Props, State> {
   };
 
   render() {
-    const { page } = this.props;
+    const { page, defaultWidth, defaultHeight } = this.props;
     const { hasError } = this.state;
-    const { width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT } = page;
+    const { width = defaultWidth, height = defaultHeight } = page;
 
     return (
       <span className={styles.container}>

--- a/src/types.js
+++ b/src/types.js
@@ -2,6 +2,11 @@ import type { ChapterMetadata } from 'poketo';
 
 export type HomeTabId = 'now-reading' | 'library';
 
+export type PageDimensions = {
+  width: number,
+  height: number,
+};
+
 export type FeedItem = {
   linkTo?: string,
   lastReadChapterId: BookmarkLastReadChapterId,

--- a/src/views/reader-view.js
+++ b/src/views/reader-view.js
@@ -10,7 +10,7 @@ import Button from '../components/button';
 import DotLoader from '../components/loader-dots';
 import Icon from '../components/icon';
 import ReaderHeader from '../components/reader-header';
-import ReaderPageImage from '../components/reader-page-image';
+import ReaderPageImageList from '../components/reader-page-image-list';
 import ReaderNavigation from '../components/reader-navigation';
 import ReaderFooter from '../components/reader-footer';
 import utils from '../utils';
@@ -274,11 +274,7 @@ class ReaderView extends Component<Props> {
         </Head>
         <div className="pt-5 pb-4 mh-auto w-90p-m ta-center mw-900">
           <div className="pt-4">
-            {chapter.pages.map(page => (
-              <div key={page.id} className="mb-2 mb-3-m">
-                <ReaderPageImage page={page} />
-              </div>
-            ))}
+            <ReaderPageImageList pages={chapter.pages} />
           </div>
         </div>
       </Fragment>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,6 +1392,11 @@ array-map@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
   integrity sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=
 
+array-most-common@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-most-common/-/array-most-common-1.0.0.tgz#c5d648c3bb99eedac7f25b04862e36ac1acbee5b"
+  integrity sha512-Bqw0N5yoRQrFIYSVPo6wzzaiRbGA/ht1n5G6uO/rqBtZWudFqR+XGlUfbEhw+bn72prBKjVhJGwoQvYUmOrhAw==
+
 array-reduce@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"


### PR DESCRIPTION
Previously, we assumed a static size for all images being loaded. This resulted in a bunch of relayout and page jumping because the default size rarely aligned with the actual image size.

This PR introduces a smarter method, where the most common image dimensions from the images that are already loaded gets used as the placeholder image size. In some quick testing, it seems to work quite well, even for all-over-the-place series like _Shingeki no Kyojin_.