### PR TITLE
Add JSON Feed Support

### DIFF
--- a/api/src/handlers/fetch-feed.js
+++ b/api/src/handlers/fetch-feed.js
@@ -37,7 +37,7 @@ function jsonFeedForSeries(series: Series) {
       url: chapter.url,
       title: getChapterLabel(chapter),
       date_published: (new Date(chapter.createdAt * 1000)).toISOString(),
-      content_html: 'Read this chapter at ' + chapter.url,
+      content_html: `Read this chapter on <a href="${chapter.url}">${series.site.name}</a>.`,
     })) : [],
   };
   /* eslint-enable camelcase */

--- a/api/src/handlers/fetch-feed.js
+++ b/api/src/handlers/fetch-feed.js
@@ -1,0 +1,51 @@
+// @flow
+
+import type { Context } from 'koa';
+import poketo, { type ChapterMetadata, type Series } from 'poketo';
+
+function getChapterLabel(chapter: ChapterMetadata): string {
+  if (chapter.chapterNumber) {
+    return `Chapter ${chapter.chapterNumber}`;
+  }
+
+  if (chapter.title) {
+    return chapter.title;
+  }
+
+  if (chapter.volumeNumber) {
+    return `Volume ${chapter.volumeNumber}`;
+  }
+
+  return 'Unknown';
+}
+
+function jsonFeedForSeries(series: Series) {
+  /* eslint-disable camelcase */
+  return {
+    version: 'https://jsonfeed.org/version/1',
+    title: series.title,
+    description: series.description,
+    author: {
+      name: series.author,
+    },
+    home_page_url: series.url,
+    feed_url: `https://api.poketo.app/feed/${series.id}.json`,
+    favicon: 'https://poketo.app/favicon.png',
+    expired: series.status === 'COMPLETED',
+    items: series.chapters ? series.chapters.map(chapter => ({
+      id: chapter.id,
+      url: chapter.url,
+      title: getChapterLabel(chapter),
+      date_published: (new Date(chapter.createdAt * 1000)).toISOString(),
+      content_html: 'Read this chapter at ' + chapter.url,
+    })) : [],
+  };
+  /* eslint-enable camelcase */
+}
+
+export default async function(ctx: Context, id: string) {
+  const type = poketo.getType(id);
+  ctx.assert(type === 'series', 400, 'Please provide a valid Poketo ID.');
+  const series = await poketo.getSeries(id);
+  ctx.body = jsonFeedForSeries(series);
+}

--- a/api/src/handlers/fetch-feed.js
+++ b/api/src/handlers/fetch-feed.js
@@ -47,5 +47,9 @@ export default async function(ctx: Context, id: string) {
   const type = poketo.getType(id);
   ctx.assert(type === 'series', 400, 'Please provide a valid Poketo ID.');
   const series = await poketo.getSeries(id);
+  ctx.log.info(
+    'Fetched series feed: %s',
+    id
+  );
   ctx.body = jsonFeedForSeries(series);
 }

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -8,6 +8,7 @@ import error from './handlers/error';
 import meta from './handlers/meta';
 import * as collections from './handlers/collections';
 import fetch from './handlers/fetch';
+import fetchFeed from './handlers/fetch-feed';
 
 app.use(error);
 app.on('error', () => {});
@@ -49,6 +50,7 @@ app.use(route.post(bookmarkRoot + '/:seriesId/read', collections.markAsRead));
 
 app.use(route.get('/series', fetch));
 app.use(route.get('/chapter', fetch));
+app.use(route.get('/feed/:id.json', fetchFeed));
 
 /**
  * Server

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,6 @@
 # proxy api requests
 /api/* https://api.poketo.app/:splat 200
+/feed/* https://api.poketo.app/feed/:splat 200
 
 # serve index.html for all pages
 /*  /index.html  200

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,6 +89,7 @@ const utils = {
     `https://www.reddit.com/r/manga/search?q=${encodeURIComponent(
       searchString,
     ).replace(/%20/g, '+')}${sortByNew ? '&sort=new' : ''}&restrict_sr=on`,
+  getFeedUrl: (seriesId: string) => `/feed/${seriesId}.json`,
 
   getUnfollowMessage: (series: { title: string }) =>
     `Do you want to unfollow ${

--- a/src/views/series-view.js
+++ b/src/views/series-view.js
@@ -92,7 +92,9 @@ const SeriesPage = ({
   return (
     <div className="pb-5">
       <ScrollReset />
-      <Head title={series.title} />
+      <Head title={series.title}>
+        <link href={utils.getFeedUrl(series.id)} rel="feed" type="application/json" title={series.title} />
+      </Head>
       <div className="mw-600 w-100p mh-auto p-relative">
         <header className="p-relative z-3 x xa-center xj-spaceBetween pa-2 mb-3 c-white">
           <BackButtonContainer>
@@ -117,6 +119,14 @@ const SeriesPage = ({
                   iconBefore={<Icon name="new-tab" {...iconProps} />}
                   label={`Open on /r/manga`}
                   href={utils.getRedditUrl(series.title)}
+                  onClick={close}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                />
+                <Popover.Item
+                  iconBefore={<Icon name="feed" {...iconProps} />}
+                  label={`Open feed`}
+                  href={utils.getFeedUrl(series.id)}
                   onClick={close}
                   target="_blank"
                   rel="noreferrer noopener"


### PR DESCRIPTION
This PR introduces a new route to the API to allow sharing series data as a [JSON Feed](https://jsonfeed.org/).

### Why bother?

Poketo's aims to democratize the reading of manga series. That might mean not using Poketo's reader. By publishing Poketo's series information as an open standard like JSON Feed, it allows people to read and get updates to manga in an RSS Reader of choice (eg. [Feedbin](https://feedbin.com/)).

### Why JSON Feed?

Because it is easy to implement, and works in a few different RSS readers. It also doesn't preclude the potential to support other formats like RSS or Atom in the future.

### How do I use this?

You can access a series' feed from two different places:
1. From a series page, click on the "Open Feed" link in the header
2. Go directly to `https://poketo.app/feed/:series.json`

### To-do

- [x] Add JSON feed endpoint
- [x] Add affordances to access feed 
- [ ] ~~Add image content to posts~~